### PR TITLE
Update wording:

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [RFC5322](https://tools.ietf.org/html/rfc5322#section-3.4.1) allows the usage of `+` in e-mails.
 
-Some mail services interpret `+` such that all mail that is sent to user+foo@example.com,
-user+bar@example.com ends up in user@example.com mailbox.
+All mail that is sent to user+foo@example.com or user+bar@example.com **should** end up in user@example.com mailbox.
+
 This helps managing your inbox, is extremely useful if you want to detect a service that sells user
 e-mails to spammers and just keeps yourself more secure.
 


### PR DESCRIPTION
This sort of revert the changes made in https://github.com/rwz/cant-parse-emails/pull/20 which is, in my understanding, blurring the lines between what is standard and what is not. I think the wording prior to that PR were better as they put more emphasis on the fact that supporting `+` in the local part is standard. Mail clients should redirect to the proper mailbox, even if some don’t.